### PR TITLE
add new password-related custom queries

### DIFF
--- a/bloodhoundcli/data/customqueries.json
+++ b/bloodhoundcli/data/customqueries.json
@@ -1068,6 +1068,36 @@
       ]
     },
     {
+      "name": "Users where password equals username (including reverse spelling)",
+      "category": "Passwords",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH (c:Credential)-[:AssignedTo]->(u:User {enabled: true}) WHERE toLower(c.password) = toLower(u.samaccountname) OR toLower(c.password) = toLower(reverse(u.samaccountname)) SET c.weak = true RETURN u.name"
+        }
+      ]
+    },
+    {
+      "name": "Users where password contains username",
+      "category": "Passwords",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH (c:Credential)-[:AssignedTo]->(u:User {enabled: true}) WHERE toLower(c.password) CONTAINS toLower(u.samaccountname) SET c.weak = true RETURN u.name"
+        }
+      ]
+    },
+    {
+      "name": "Users where password contains a part of the user's domain",
+      "category": "Passwords",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH (c:Credential)-[:AssignedTo]->(u:User {enabled: true}) WITH c, u, split(u.domain, '.') AS parts WHERE toLower(c.password) CONTAINS any(part IN parts[0..-1] WHERE toLower(c.password) CONTAINS toLower(part)) SET c.weak = true RETURN u.name"
+        }
+      ]
+    },
+    {
       "name": "Users with empty password",
       "category": "Passwords",
       "queryList": [


### PR DESCRIPTION
This PR adds the following custom Bloodhound queries:

- get users whose password contains their username or the reverse of the username (for example, if `alice` uses the password `ecila`, it would be considered as "password equals username")
- get users whose password _contains_ their username (for example, if `alice` uses `I.am.Alice2024!` as the password)
- get users whose password _contains_ any part of the domain except the top-level part (for example, if `sub.corp.local\alice` uses `Corp1998!` or `Sub2004!` as the password)