### PR TITLE
Add new category "Stale Objects" for custom Bloodhound queries

### DIFF
--- a/bloodhoundcli/data/customqueries.json
+++ b/bloodhoundcli/data/customqueries.json
@@ -1001,66 +1001,6 @@
       ]
     },
     {
-      "name": "T0 users that never logged on",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE coalesce(u.lastlogon, 0) <= 0 AND coalesce(u.lastlogontimestamp, 0) <= 0 RETURN p"
-        }
-      ]
-    },
-    {
-      "name": "Enabled users that never logged on",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE coalesce(u.lastlogon, 0) <= 0 AND coalesce(u.lastlogontimestamp, 0) <= 0 RETURN p"
-        }
-      ]
-    },
-    {
-      "name": "T0 users without logon since 90 days",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE NOT coalesce(u.active, false) RETURN p"
-        }
-      ]
-    },
-    {
-      "name": "Enabled users without logon since 90 days",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE NOT coalesce(u.active, false) AND (coalesce(u.lastlogon, 0) > 0 OR coalesce(u.lastlogontimestamp, 0) > 0) RETURN p"
-        }
-      ]
-    },
-    {
-      "name": "T0 users that never set a password",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE u.pwdlastset <= 0 RETURN p"
-        }
-      ]
-    },
-    {
-      "name": "Enabled users that never set a password",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE u.pwdlastset <= 0 RETURN p"
-        }
-      ]
-    },
-    {
       "name": "T0 users without password change since a year",
       "category": "Audit",
       "queryList": [
@@ -1171,16 +1111,6 @@
       ]
     },
     {
-      "name": "Disabled users",
-      "category": "Audit",
-      "queryList": [
-        {
-          "final": true,
-          "query": "MATCH p = (:Domain)-[:Contains*1..]->(:User {enabled: false}) RETURN p"
-        }
-      ]
-    },
-    {
       "name": "Active computers with unsupported OS",
       "category": "Audit",
       "queryList": [
@@ -1201,8 +1131,78 @@
       ]
     },
     {
+      "name": "T0 users that never logged on",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE coalesce(u.lastlogon, 0) <= 0 AND coalesce(u.lastlogontimestamp, 0) <= 0 RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "Enabled users that never logged on",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE coalesce(u.lastlogon, 0) <= 0 AND coalesce(u.lastlogontimestamp, 0) <= 0 RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "T0 users without logon since 90 days",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE NOT coalesce(u.active, false) RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "Enabled users without logon since 90 days",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE NOT coalesce(u.active, false) AND (coalesce(u.lastlogon, 0) > 0 OR coalesce(u.lastlogontimestamp, 0) > 0) RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "T0 users that never set a password",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true, tier: 0}) WHERE u.pwdlastset <= 0 RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "Enabled users that never set a password",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(u:User {enabled: true}) WHERE u.pwdlastset <= 0 RETURN p"
+        }
+      ]
+    },
+    {
+      "name": "Disabled users",
+      "category": "Stale Objects",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (:Domain)-[:Contains*1..]->(:User {enabled: false}) RETURN p"
+        }
+      ]
+    },
+    {
       "name": "T0 computers without logon",
-      "category": "Audit",
+      "category": "Stale Objects",
       "queryList": [
         {
           "final": true,
@@ -1212,7 +1212,7 @@
     },
     {
       "name": "Enabled computers without logon",
-      "category": "Audit",
+      "category": "Stale Objects",
       "queryList": [
         {
           "final": true,
@@ -1222,7 +1222,7 @@
     },
     {
       "name": "T0 computers without logon since 90 days",
-      "category": "Audit",
+      "category": "Stale Objects",
       "queryList": [
         {
           "final": true,
@@ -1232,7 +1232,7 @@
     },
     {
       "name": "Enabled computers without logon since 90 days",
-      "category": "Audit",
+      "category": "Stale Objects",
       "queryList": [
         {
           "final": true,
@@ -1242,7 +1242,7 @@
     },
     {
       "name": "Disabled computers",
-      "category": "Audit",
+      "category": "Stale Objects",
       "queryList": [
         {
           "final": true,


### PR DESCRIPTION
This PR adds a new category "Stale Objects" for the custom Bloodhound queries.
It does not change any queries, but arranges them more clearly so that they can be found more conveniently through Bloodhound's GUI:

![image](https://github.com/user-attachments/assets/1243fef4-bead-4b26-961b-bc8e8ff8dc2b)
