### PR TITLE
Added a new customquery

### DIFF
--- a/bloodhoundcli/data/customqueries.json
+++ b/bloodhoundcli/data/customqueries.json
@@ -801,12 +801,12 @@
       ]
     },
     {
-      "name": "Paths from owned domain to other domain via Password Reuse",
+      "name": "Cross-domain password reuse from owned domains",
       "category": "Domains",
       "queryList": [
         {
           "final": true,
-          "query": "MATCH p = (d:Domain {owned: true})-[:Contains*1..]->(a:User)-[:AssignedTo]-(c:Credential)-[:HasCredential]-(b: User {enabled: true, tier: 0})<-[:Contains*1..]-(e:Domain) where d<>e RETURN p"
+          "query": "MATCH p = (:Domain {owned: true})-[:Contains*1..]->(:User)-[:HasCredential]->(:Credential)-[:AssignedTo]->(:User {enabled: true})<-[:Contains*1..]-(:Domain {owned: false}) RETURN p"
         }
       ]
     },

--- a/bloodhoundcli/data/customqueries.json
+++ b/bloodhoundcli/data/customqueries.json
@@ -801,6 +801,16 @@
       ]
     },
     {
+      "name": "Paths from owned domain to other domain via Password Reuse",
+      "category": "Domains",
+      "queryList": [
+        {
+          "final": true,
+          "query": "MATCH p = (d:Domain {owned: true})-[:Contains*1..]->(a:User)-[:AssignedTo]-(c:Credential)-[:HasCredential]-(b: User {enabled: true, tier: 0})<-[:Contains*1..]-(e:Domain) where d<>e RETURN p"
+        }
+      ]
+    },
+    {
       "name": "Mark active computers (no output)",
       "category": "AD Post Processing",
       "queryList": [


### PR DESCRIPTION
Added a new customquery to query all shared passwords (also for disabled users) from a owned domain (a) to another domain (b) where the password belongs to a user in domain 'b' that is tier 0 and enabled. 
This is useful when you have a dc-sync of domain 'a' to takeover domain 'b'. 