### PR TITLE
Catch for smb.db inconsistency error

### DIFF
--- a/bloodhoundcli/netexec.py
+++ b/bloodhoundcli/netexec.py
@@ -56,7 +56,11 @@ def import_users(nxcdb: sqlite3.Connection, neo4j: Database) -> None:
             upn = f'{username}@{userdomain}'
         else:
             # It's a local user. Hence, we have to find its host based on the hostname in the column `users.domain`.
-            hostname, hostdomain = nxcdb.execute('SELECT h.hostname, h.domain FROM users AS u JOIN hosts AS h ON lower(u.domain) = lower(h.hostname) WHERE u.id = ?', (int(userid),)).fetchone()
+            result = nxcdb.execute('SELECT h.hostname, h.domain FROM users AS u JOIN hosts AS h ON lower(u.domain) = lower(h.hostname) WHERE u.id = ?', (int(userid),)).fetchone()
+            if not result:
+                print(f'\033[31mWARNING: Database inconsistency detected! User with id={userid} has no corresponding host. Fix manually and re-run')
+                return
+            hostname, hostdomain = result
             is_domain_computer = '.' in hostdomain
             if is_domain_computer:
                 fqdn = f'{hostname}.{hostdomain}'


### PR DESCRIPTION
Maybe an edge-case but the following situation has been encountered recently upon trying to import the smb.db from netexec: Local admin creds in the smb.db user table had no corresponding host in the hosts table as can be seen in the following example below:
![image](https://github.com/user-attachments/assets/3d3c72da-e55e-454d-9e98-b3efd6903f2c)
The user `ADMINISTRATOR` has a local domain ending with `5A20`.
![image](https://github.com/user-attachments/assets/c7020d32-ffe0-45f2-aad1-27763443dc2d)
Upon checking the hosts table, we find no corresponding host. This results in a failing JOIN-operation and a `None` result, crashing the entire program.
In order for the import of the smb.db to finish, one needs to manually insert the host into the hosts table:
![image](https://github.com/user-attachments/assets/ccc13ecf-5aa6-45b8-9290-da4930a285b9)
The origin of such an inconsistency is not clear as one should assume that netexec would include every host it has local admin creds for. The error was encountered multiple times (~10) in this specific case.

The suggested fix tries to account for the error by checking if the returned query result is empty and informing the user to fix the database first.